### PR TITLE
fix missing dependency and circular import

### DIFF
--- a/mensages.py
+++ b/mensages.py
@@ -9,7 +9,6 @@ import warnings
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from nltk.corpus import stopwords
-from main import *
 
 # Desativar avisos desnecessários
 warnings.filterwarnings("ignore", category=DeprecationWarning)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ nltk==3.8.1
 beautifulsoup4==4.12.2
 lxml==4.9.3
 numpy==1.25.2
+scikit-learn==1.3.2


### PR DESCRIPTION
## Summary
- add scikit-learn dependency
- remove circular import from messages module

## Testing
- `python -m py_compile main.py mensages.py`
- `pip install -r requirements.txt` *(fails: Could not connect to proxy, no matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad112885dc8330938d96ca0be8a12c