### PR TITLE
Add conditional NLTK resource downloads

### DIFF
--- a/main.py
+++ b/main.py
@@ -168,6 +168,8 @@ class WhatsAppBot:
 
 
 def main():
+    download_nltk_resources()
+
     # URL para carregar conteúdo para o ConversaBot
     url = "https://pt.wikipedia.org/wiki/Oakley,_Inc."  # URL de exemplo
 
@@ -176,8 +178,6 @@ def main():
 
     root = WhatsAppBot(bot)
     time.sleep(2)
-
-    download_nltk_resources()
 
     # Lista de palavras
     palavras = ['olá', 'horário', 'olhar']

--- a/mensages.py
+++ b/mensages.py
@@ -14,14 +14,26 @@ from nltk.corpus import stopwords
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings("ignore", category=UserWarning)
 
+# Função utilitária para garantir que um recurso do NLTK esteja disponível
+def ensure_nltk_resource(name, path):
+    """Verifica se o recurso está disponível; se não, faz o download."""
+    try:
+        nltk.data.find(path)
+    except LookupError:
+        nltk.download(name)
 
-# Função para baixar as dependências do NLTK
+
+# Função para baixar as dependências do NLTK apenas quando necessário
 def download_nltk_resources():
-    nltk.download('wordnet')
-    nltk.download('omw')
-    nltk.download('punkt')
-    nltk.download('rslp')
-    nltk.download('stopwords')
+    resources = [
+        ('wordnet', 'corpora/wordnet'),
+        ('omw', 'corpora/omw'),
+        ('punkt', 'tokenizers/punkt'),
+        ('rslp', 'stemmers/rslp'),
+        ('stopwords', 'corpora/stopwords'),
+    ]
+    for name, path in resources:
+        ensure_nltk_resource(name, path)
 
 
 # Função para gerar lista de sinônimos


### PR DESCRIPTION
## Summary
- Add utility to ensure NLTK resources exist and download if missing
- Only download required NLTK resources when needed
- Initialize NLTK resources before chatbot setup

## Testing
- `python -m py_compile mensages.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad162e050c8330b0f54ee455ddecf8