### PR TITLE
Handle 403 errors when loading web page

### DIFF
--- a/mensages.py
+++ b/mensages.py
@@ -86,7 +86,9 @@ def compilar_keywords(keywords):
 # Classe ConversaBot para gerar respostas dinâmicas
 class ConversaBot:
     def __init__(self, url):
-        self.codigo_html = urllib.request.urlopen(url).read()
+        headers = {"User-Agent": "Mozilla/5.0"}
+        req = urllib.request.Request(url, headers=headers)
+        self.codigo_html = urllib.request.urlopen(req).read()
         self.html_processado = bs.BeautifulSoup(self.codigo_html, 'lxml')
         self.texto = self._extrair_texto()
 


### PR DESCRIPTION
## Summary
- Add custom User-Agent header before urlopen to prevent 403 errors

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68ae6a5db6988330a6c32e9f39851543